### PR TITLE
Fix: Adjust Jekyll baseurl for consistent behavior

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: A comprehensive guide to using ScalaMock - a native Scala mocking f
 theme: just-the-docs
 
 url: https://eclypsium-ef.github.io
-baseurl: "/Tutorial_ScalaMocks"
+baseurl: ""
 
 aux_links:
   Repository: https://github.com/eclypsium-ef/Tutorial_ScalaMocks


### PR DESCRIPTION
I've set `baseurl: ""` in `_config.yml` to simplify local development and will rely on the GitHub Actions workflow to inject the correct baseurl (repository name) during the Jekyll build process for GitHub Pages.

This change ensures that asset paths (like for CSS, JS, and images) and internal page links are generated correctly for both local previews and the deployed GitHub Pages site. This should resolve issues where the site might appear broken due to incorrect resource paths or non-functional links, including problems with Mermaid diagram rendering if its JavaScript assets were not loading.