### PR TITLE
I've made some adjustments to the Jekyll build process and base URL c…

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,9 +34,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-          working-directory: '${{ github.workspace }}/docs'  # Set working directory for Ruby setup
+          # bundler-cache, cache-version and working-directory removed
+      - name: Install dependencies
+        run: bundle install # This will run in 'docs' due to job defaults
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ description: A comprehensive guide to using ScalaMock - a native Scala mocking f
 theme: just-the-docs
 
 url: https://eclypsium-ef.github.io
-baseurl: "/Tutorial_ScalaMocks"
+baseurl: ""
 
 aux_links:
   Repository: https://github.com/eclypsium-ef/Tutorial_ScalaMocks


### PR DESCRIPTION
…onfiguration.

- In `.github/workflows/pages.yml`:
  - I removed `bundler-cache: true` from the `ruby/setup-ruby` step.
  - I added an explicit `bundle install` step after Ruby setup.
  - This should ensure dependencies are installed correctly in the `docs` directory, which was causing an error during the Jekyll build.

- In `docs/_config.yml`:
  - I set `baseurl: ""` to make local development easier for you.
  - The GitHub Actions workflow will handle setting the correct `baseurl` when deploying.
  - This should lead to consistent URLs for assets and internal links, whether you're working locally or viewing the deployed site.